### PR TITLE
feat: create separate transport_type for w3c data

### DIFF
--- a/test_lib/schema.xsd
+++ b/test_lib/schema.xsd
@@ -57,6 +57,7 @@
                         <xs:enumeration value="hec_raw"/>
                         <xs:enumeration value="hec_event"/>
                         <xs:enumeration value="file_monitor"/>
+                        <xs:enumeration value="file_monitor_w3c"/>
                       </xs:restriction>
                     </xs:simpleType>
                   </xs:attribute>

--- a/test_lib/test_transport_attrib.py
+++ b/test_lib/test_transport_attrib.py
@@ -87,6 +87,7 @@ def check_transport_params(filename):
         "hec_event",
         "forwarder",
         "file_monitor",
+        "file_monitor_w3c",
         "scripted_input",
         "scripted input",
         "hec_raw",


### PR DESCRIPTION
Create separate transport-type file_monitor_w3c. w3c is not supported currently in the Requirement test.
Adding this will not cause ingestion failure for this type and skip the test