### PR TITLE
feat: support xml files

### DIFF
--- a/test_lib/common_util.py
+++ b/test_lib/common_util.py
@@ -1,0 +1,17 @@
+import os
+
+
+def return_folder_contents(input_folder):
+    file_list = []
+    for dirpath, dirs, files in os.walk(input_folder):
+        if not os.listdir(dirpath):
+            print("No files in the directory.")
+            exit(1)
+        for filename in files:
+            fname = os.path.join(dirpath, filename)
+            if fname.endswith(".log") or fname.endswith(".xml"):
+                file_list.append(fname)
+            else:
+                print(f"invalid file extension file {filename}")
+                exit(1)
+    return file_list

--- a/test_lib/test_cim.py
+++ b/test_lib/test_cim.py
@@ -6,6 +6,7 @@ import logging
 import os.path
 import sys
 from xml.etree import cElementTree as ET
+
 from common_util import *
 
 logger = logging.getLogger()

--- a/test_lib/test_cim.py
+++ b/test_lib/test_cim.py
@@ -7,7 +7,7 @@ import os.path
 import sys
 from xml.etree import cElementTree as ET
 
-from common_util import *
+from common_util import return_folder_contents
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)

--- a/test_lib/test_cim.py
+++ b/test_lib/test_cim.py
@@ -6,7 +6,7 @@ import logging
 import os.path
 import sys
 from xml.etree import cElementTree as ET
-
+from common_util import *
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 output_file_handler = logging.FileHandler("test_cim_output.txt", mode="w")
@@ -391,11 +391,9 @@ def main(argv):
         if os.path.isfile(input_dir):
             cim_matching(input_dir, str(json_dir))
         else:
-            for subdir, _, files in os.walk(input_dir):
-                for file in files:
-                    filename = os.path.join(subdir, file)
-                    if filename.endswith(".log") or filename.endswith(".xml"):
-                        cim_matching(filename, str(json_dir))
+            file_list = return_folder_contents(input_dir)
+            for filename in file_list:
+                cim_matching(filename, str(json_dir))
     else:
         print("Invalid Input")
     if JENKINS_STATUS is False:

--- a/test_lib/test_cim.py
+++ b/test_lib/test_cim.py
@@ -394,7 +394,7 @@ def main(argv):
             for subdir, _, files in os.walk(input_dir):
                 for file in files:
                     filename = os.path.join(subdir, file)
-                    if filename.endswith(".log"):
+                    if filename.endswith(".log") or filename.endswith(".xml"):
                         cim_matching(filename, str(json_dir))
     else:
         print("Invalid Input")

--- a/test_lib/test_cim.py
+++ b/test_lib/test_cim.py
@@ -7,6 +7,7 @@ import os.path
 import sys
 from xml.etree import cElementTree as ET
 from common_util import *
+
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 output_file_handler = logging.FileHandler("test_cim_output.txt", mode="w")

--- a/test_lib/test_transport_attrib.py
+++ b/test_lib/test_transport_attrib.py
@@ -18,7 +18,7 @@ import logging
 import os
 import sys
 from xml.etree import cElementTree as ET
-
+from common_util import *
 from lxml import etree
 
 logger = logging.getLogger()
@@ -112,11 +112,9 @@ def parse_input(input_arg):
         if os.path.isfile(input_arg):
             check_transport_params(input_arg)
         elif os.path.isdir(input_arg):
-            for subdir, _, files in os.walk(input_arg):
-                for file in files:
-                    if file.endswith(".log") or file.endswith(".xml"):
-                        filename = os.path.join(subdir, file)
-                        check_transport_params(filename)
+            file_list = return_folder_contents(input_arg)
+            for filename in file_list:
+                check_transport_params(filename)
     else:
         logger.debug("Invalid input path")
     if not INVALID:

--- a/test_lib/test_transport_attrib.py
+++ b/test_lib/test_transport_attrib.py
@@ -114,7 +114,7 @@ def parse_input(input_arg):
         elif os.path.isdir(input_arg):
             for subdir, _, files in os.walk(input_arg):
                 for file in files:
-                    if file.endswith(".log"):
+                    if file.endswith(".log") or file.endswith(".xml"):
                         filename = os.path.join(subdir, file)
                         check_transport_params(filename)
     else:

--- a/test_lib/test_transport_attrib.py
+++ b/test_lib/test_transport_attrib.py
@@ -18,6 +18,7 @@ import logging
 import os
 import sys
 from xml.etree import cElementTree as ET
+
 from common_util import *
 from lxml import etree
 

--- a/test_lib/test_transport_attrib.py
+++ b/test_lib/test_transport_attrib.py
@@ -19,7 +19,7 @@ import os
 import sys
 from xml.etree import cElementTree as ET
 
-from common_util import *
+from common_util import return_folder_contents
 from lxml import etree
 
 logger = logging.getLogger()

--- a/test_lib/test_unicode_char.py
+++ b/test_lib/test_unicode_char.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 
-from common_util import *
+from common_util import return_folder_contents
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)

--- a/test_lib/test_unicode_char.py
+++ b/test_lib/test_unicode_char.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+from common_util import *
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -35,11 +36,9 @@ def parse_input(input_arg):
         if os.path.isfile(input_arg):
             test_unicode_char(input_arg)
         elif os.path.isdir(input_arg):
-            for subdir, _, files in os.walk(input_arg):
-                for file in files:
-                    if file.endswith(".log") or file.endswith(".xml"):
-                        filename = os.path.join(subdir, file)
-                        test_unicode_char(filename)
+            file_list = return_folder_contents(input_arg)
+            for filename in file_list:
+                test_unicode_char(filename)
     else:
         logger.debug("Invalid input path")
     if not INVALID:

--- a/test_lib/test_unicode_char.py
+++ b/test_lib/test_unicode_char.py
@@ -37,7 +37,7 @@ def parse_input(input_arg):
         elif os.path.isdir(input_arg):
             for subdir, _, files in os.walk(input_arg):
                 for file in files:
-                    if file.endswith(".log"):
+                    if file.endswith(".log") or file.endswith(".xml"):
                         filename = os.path.join(subdir, file)
                         test_unicode_char(filename)
     else:

--- a/test_lib/test_unicode_char.py
+++ b/test_lib/test_unicode_char.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import sys
+
 from common_util import *
 
 logger = logging.getLogger()

--- a/test_lib/validate_xml.py
+++ b/test_lib/validate_xml.py
@@ -17,6 +17,7 @@ import argparse
 import logging
 import os
 import sys
+from common_util import *
 
 import lxml
 from lxml import etree
@@ -65,11 +66,9 @@ def parse_input(input_arg, schema_arg):
         if os.path.isfile(input_arg):
             validate_input(input_arg, schema_arg)
         elif os.path.isdir(input_arg):
-            for subdir, _, files in os.walk(input_arg):
-                for file in files:
-                    if file.endswith(".log") or file.endswith(".xml"):
-                        filename = os.path.join(subdir, file)
-                        validate_input(filename, schema_arg)
+            file_list = return_folder_contents(input_arg)
+            for filename in file_list:
+                validate_input(filename, schema_arg)
     else:
         logger.debug("Invalid input path")
     if not INVALID:

--- a/test_lib/validate_xml.py
+++ b/test_lib/validate_xml.py
@@ -17,9 +17,9 @@ import argparse
 import logging
 import os
 import sys
-from common_util import *
 
 import lxml
+from common_util import *
 from lxml import etree
 
 logger = logging.getLogger()

--- a/test_lib/validate_xml.py
+++ b/test_lib/validate_xml.py
@@ -19,7 +19,7 @@ import os
 import sys
 
 import lxml
-from common_util import *
+from common_util import return_folder_contents
 from lxml import etree
 
 logger = logging.getLogger()

--- a/test_lib/validate_xml.py
+++ b/test_lib/validate_xml.py
@@ -67,7 +67,7 @@ def parse_input(input_arg, schema_arg):
         elif os.path.isdir(input_arg):
             for subdir, _, files in os.walk(input_arg):
                 for file in files:
-                    if file.endswith(".log"):
+                    if file.endswith(".log") or file.endswith(".xml"):
                         filename = os.path.join(subdir, file)
                         validate_input(filename, schema_arg)
     else:

--- a/test_lib/xml_format_checker.py
+++ b/test_lib/xml_format_checker.py
@@ -18,6 +18,7 @@ import os
 import sys
 from xml.sax import make_parser
 from xml.sax.handler import ContentHandler
+
 from common_util import *
 
 logger = logging.getLogger()

--- a/test_lib/xml_format_checker.py
+++ b/test_lib/xml_format_checker.py
@@ -53,9 +53,9 @@ def check_xml_format(input_folder):
             else:
                 logger.debug(fname + ":Invalid input file format")
                 test_status = False
-            if contains_XML and contains_log:
-                logger.error(" Failed: Files should either be .log or .xml")
-                test_status = False
+        if contains_XML and contains_log:
+            logger.error(" Failed: All files should either be .log or .xml extension")
+            test_status = False
     return test_status
 
 

--- a/test_lib/xml_format_checker.py
+++ b/test_lib/xml_format_checker.py
@@ -36,6 +36,9 @@ def parsefile(file):
 def check_xml_format(input_folder):
     for dirpath, dirs, files in os.walk(input_folder):
         contains_log, contains_XML, test_status = False, False, True
+        if not os.listdir(dirpath):
+            print("No files in the directory.")
+            exit(1)
         for filename in files:
             fname = os.path.join(dirpath, filename)
             if fname.endswith(".log") or fname.endswith(".xml"):

--- a/test_lib/xml_format_checker.py
+++ b/test_lib/xml_format_checker.py
@@ -14,10 +14,11 @@
 #    limitations under the License.
 #   #######################################################################
 import logging
-import os.path
+import os
 import sys
 from xml.sax import make_parser
 from xml.sax.handler import ContentHandler
+from common_util import *
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
@@ -34,28 +35,20 @@ def parsefile(file):
 
 
 def check_xml_format(input_folder):
-    for dirpath, dirs, files in os.walk(input_folder):
-        contains_log, contains_XML, test_status = False, False, True
-        if not os.listdir(dirpath):
-            print("No files in the directory.")
-            exit(1)
-        for filename in files:
-            fname = os.path.join(dirpath, filename)
-            if fname.endswith(".log") or fname.endswith(".xml"):
-                if fname.endswith(".log"):
-                    contains_log = True
-                else:
-                    contains_XML = True
-                try:
-                    parsefile(fname)
-                    print(f" Pass : {str(fname)}")
-                except Exception as e:
-                    test_status = False
-                    logger.debug(str(e) + "\n")
-                    logging.error(f" Failed : {str(e)}")
-            else:
-                logger.debug(fname + ":Invalid input file format")
-                test_status = False
+    file_list = return_folder_contents(input_folder)
+    contains_log, contains_XML, test_status = False, False, True
+    for fname in file_list:
+        if fname.endswith(".log"):
+            contains_log = True
+        else:
+            contains_XML = True
+        try:
+            parsefile(fname)
+            print(f" Pass : {str(fname)}")
+        except Exception as e:
+            test_status = False
+            logger.debug(str(e) + "\n")
+            logging.error(f" Failed : {str(e)}")
         if contains_XML and contains_log:
             logger.error(" Failed: All files should either be .log or .xml extension")
             test_status = False

--- a/test_lib/xml_format_checker.py
+++ b/test_lib/xml_format_checker.py
@@ -19,7 +19,7 @@ import sys
 from xml.sax import make_parser
 from xml.sax.handler import ContentHandler
 
-from common_util import *
+from common_util import return_folder_contents
 
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
- check added to **xml_format_checker.py** to fail the test if we have **a mixture of .log and. XML files.**

- XML format check is the first test. If this fails none of the other tests will run. 

- All other tests are moved to support both XML and .log files.

Required to support - https://github.com/splunk/pytest-splunk-addon/pull/550 with unit tests
Please review.
tested Github action with juniper addon - https://github.com/splunk/splunk-add-on-for-juniper/pull/277 